### PR TITLE
fix: Restore correct Tauri v2.7.1 versions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ This file documents all significant changes made to the `project_arcade` applica
 
 ### 08-06-2025
 
-- **Security Fix**: Fixed high-severity security vulnerability "Insufficiently Protected Credentials" in Tauri configuration. Removed `TAURI_` from `envPrefix` and eliminated all TAURI environment variable exposure to prevent bundling of sensitive credentials (`TAURI_PRIVATE_KEY`, `TAURI_KEY_PASSWORD`) into frontend code. Note: Snyk continues to flag this until Tauri 2 upgrade, but the vulnerability is actually resolved in our configuration. Added `.snyk` policy file to suppress the warning since the fix is implemented. (`vite.config.ts`, `.snyk`)
+- **Security Fix**: Fixed high-severity security vulnerability "Insufficiently Protected Credentials" in Tauri configuration. Removed `TAURI_` from `envPrefix` and eliminated all TAURI environment variable exposure to prevent bundling of sensitive credentials (`TAURI_PRIVATE_KEY`, `TAURI_KEY_PASSWORD`) into frontend code. Restored correct Tauri v2.7.1 versions after accidental downgrade. Note: Snyk continues to flag this until Tauri 2 upgrade, but the vulnerability is actually resolved in our configuration. (`vite.config.ts`, `package.json`)
 - **Age Rating API Integration**: Updated IGDB age rating fetching to use the proper `age_rating_categories` endpoint for accurate ESRB rating retrieval instead of deprecated field mapping. (`src-tauri/src/services/metadata.rs`)
   - **New API Endpoint**: Added `fetch_age_rating_details()` function that calls the proper `https://api.igdb.com/v4/age_rating_categories` endpoint
   - **Proper Rating Mapping**: The new function fetches the actual rating details and maps them to ESRB equivalents

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/cli": "^1.5.8",
+    "@tauri-apps/cli": "^2.7.1",
     "pinia": "^2.1.7",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"
   },
   "devDependencies": {
-    "@tauri-apps/api": "^1.5.8",
+    "@tauri-apps/api": "^2.7.1",
     "@types/node": "^20.5.9",
     "@vitejs/plugin-vue": "^4.2.3",
     "autoprefixer": "^10.4.14",


### PR DESCRIPTION
- Revert accidental downgrade from Tauri v2.7.1 to v1.5.8
- Restore @tauri-apps/cli and @tauri-apps/api to ^2.7.1
- Maintain security fix in vite.config.ts (removed TAURI_ from envPrefix)
- Fix package.json to match main branch Tauri versions